### PR TITLE
Remove unneeded apk handling & optimize packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ ARG DELPACKAGES=
 
 COPY conf /conf
 
-RUN apk add --no-cache gcc g++ make git pkgconfig perl  \
-       perl-net-ssleay perl-io-socket-ssl perl-libwww wget \
-       gnutls gnutls-dev gnutls-c++ $ADDPACKAGES && \
+RUN apk add --no-cache gcc g++ make libgcc libstdc++ git  \
+       pkgconfig perl perl-net-ssleay perl-io-socket-ssl  \
+       perl-libwww wget gnutls gnutls-dev $ADDPACKAGES && \
     adduser -u 10000 -h /inspircd/ -D -S inspircd && \
     mkdir -p /src /conf && \
     cd /src && \
@@ -21,7 +21,8 @@ RUN apk add --no-cache gcc g++ make git pkgconfig perl  \
     ./configure --disable-interactive --prefix=/inspircd/ --uid 10000 --enable-gnutls $CONFIGUREARGS && \
     make && \
     make install && \
-    apk del gcc g++ make git pkgconfig perl perl-net-ssleay perl-io-socket-ssl perl-libwww wget $DELPACKAGES && \
+    apk del gcc g++ make git pkgconfig perl perl-net-ssleay perl-io-socket-ssl \
+       perl-libwww wget gnutls-dev $DELPACKAGES && \
     rm -rf /src && \
     rm -rf /inspircd/conf && ln -s /conf /inspircd/conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ ARG DELPACKAGES=
 
 COPY conf /conf
 
-RUN apk update && apk add gcc g++ make git gnutls gnutls-dev gnutls-c++ \
-       pkgconfig perl perl-net-ssleay perl-io-socket-ssl perl-libwww \
-       wget $ADDPACKAGES && \
+RUN apk add --no-cache gcc g++ make git pkgconfig perl  \
+       perl-net-ssleay perl-io-socket-ssl perl-libwww wget \
+       gnutls gnutls-dev gnutls-c++ $ADDPACKAGES && \
     adduser -u 10000 -h /inspircd/ -D -S inspircd && \
     mkdir -p /src /conf && \
     cd /src && \
@@ -21,7 +21,7 @@ RUN apk update && apk add gcc g++ make git gnutls gnutls-dev gnutls-c++ \
     ./configure --disable-interactive --prefix=/inspircd/ --uid 10000 --enable-gnutls $CONFIGUREARGS && \
     make && \
     make install && \
-    apk del gcc g++ make git perl perl-net-ssleay perl-io-socket-ssl perl-libwww wget $DELPACKAGES && \
+    apk del gcc g++ make git pkgconfig perl perl-net-ssleay perl-io-socket-ssl perl-libwww wget $DELPACKAGES && \
     rm -rf /src && \
     rm -rf /inspircd/conf && ln -s /conf /inspircd/conf
 


### PR DESCRIPTION
Refering to https://github.com/docker-library/openjdk/blob/9a0822673dffd3e5ba66f18a8547aa60faed6d08/8-jre/alpine/Dockerfile

I'm not completely sure about removing `apk update`

As the docker images are build "often" it should be okay. On the other hand the `--no-cache` parameter is not mentioned in the [alpine-linux wiki](https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Add_a_Package).