### PR TITLE
add TLS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ ARG ADDPACKAGES=
 ARG DELPACKAGES=
 
 COPY conf /conf
+COPY entrypoint.sh /inspircd/entrypoint.sh
 
 RUN apk add --no-cache gcc g++ make libgcc libstdc++ git  \
        pkgconfig perl perl-net-ssleay perl-io-socket-ssl  \
-       perl-libwww wget gnutls gnutls-dev $ADDPACKAGES && \
+       perl-libwww wget gnutls gnutls-dev gnutls-utils $ADDPACKAGES && \
     adduser -u 10000 -h /inspircd/ -D -S inspircd && \
     mkdir -p /src /conf && \
     cd /src && \
@@ -24,7 +25,9 @@ RUN apk add --no-cache gcc g++ make libgcc libstdc++ git  \
     apk del gcc g++ make git pkgconfig perl perl-net-ssleay perl-io-socket-ssl \
        perl-libwww wget gnutls-dev $DELPACKAGES && \
     rm -rf /src && \
-    rm -rf /inspircd/conf && ln -s /conf /inspircd/conf
+    rm -rf /inspircd/conf && ln -s /conf /inspircd/conf && \
+    chown -R inspircd /inspircd/ && \
+    chown -R inspircd /conf/
 
 VOLUME ["/inspircd/conf"]
 
@@ -34,9 +37,8 @@ WORKDIR /inspircd/
 
 USER inspircd
 
-EXPOSE 6667 6697
+EXPOSE 6667 6697 7000 7001
 
 HEALTHCHECK CMD  /usr/bin/nc 127.0.0.1 6667 < /dev/null || exit 1
 
-ENTRYPOINT ["/inspircd/bin/inspircd"]
-CMD ["--nofork"]
+ENTRYPOINT ["/inspircd/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,35 @@ To configure include your configuration into the container use:
 $ docker run --name inspircd -p 6667:6667 -v /path/to/your/config:/inspircd/conf/ inspircd/inspircd
 ```
 
+Default ports of this container:
+
+|Port|config            |
+|----|------------------|
+|6667|clients, plaintext|
+|6697|clients, tls      |
+|7000|server, plaintext |
+|7001|server, tls       |
+
+## TLS
+
+This container generates a self-signed TLS certificate on startup as long as none exists. To use this container with TLS enabled:
+
+```console
+$ docker run --name inspircd -p 6667:6667 -p 6697:6697 inspircd/inspircd
+```
+
+You can customize the self-signed TLS certificate using the following environment variables:
+
+* `INSP_TLS_CN`
+* `INSP_TLS_MAIL`
+* `INSP_TLS_UNIT`
+* `INSP_TLS_ORG`
+* `INSP_TLS_LOC`
+* `INSP_TLS_STATE`
+* `INSP_TLS_COUNTRY`
+* `INSP_TLS_DURATION`
+
+
 # Build extras
 
 To build extra modules you can use the `--build-arg` statement.

--- a/conf/inspircd.conf
+++ b/conf/inspircd.conf
@@ -24,8 +24,10 @@
 
 
 <bind address="" port="6667" type="clients">
+<bind address="" port="6697" type="clients" ssl="gnutls">
 
-
+<bind address="" port="7000" type="servers">
+<bind address="" port="7001" type="servers" ssl="gnutls">
 #-#-#-#-#-#-#-#-#-#-  CONNECTIONS CONFIGURATION  -#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #
 #   This is where you can configure which connections are allowed     #

--- a/conf/modules.conf
+++ b/conf/modules.conf
@@ -1691,7 +1691,7 @@
 # if enabled. You must answer 'yes' in ./configure when asked or
 # manually symlink the source for this module from the directory
 # src/modules/extra, if you want to enable this, or it will not load.
-#<module name="m_ssl_gnutls.so">
+<module name="m_ssl_gnutls.so">
 #
 #-#-#-#-#-#-#-#-#-#-#-  GNUTLS CONFIGURATION   -#-#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+if [ ! -f /inpircd/conf/cert.pem ] && [ ! -f /inpircd/conf/key.pem ]; then
+    cat > /tmp/cert.template <<EOF
+cn              = "${INSP_TLS_CN:-irc.example.com}"
+email           = "${INSP_TLS_MAIL:-nomail@example.com}"
+unit            = "${INSP_TLS_UNIT:-Server Admins}"
+organization    = "${INSP_TLS_ORG:-Example IRC Network}"
+locality        = "${INSP_TLS_LOC:-Example City}"
+state           = "${INSP_TLS_STATE:-Example State}"
+country         = "${INSP_TLS_COUNTRY:-XZ}"
+expiration_days = ${INSP_TLS_DURATION:-365}
+tls_www_client
+tls_www_server
+signing_key
+encryption_key
+cert_signing_key
+crl_signing_key
+code_signing_key
+ocsp_signing_key
+time_stamping_key
+EOF
+    /usr/bin/certtool --generate-privkey --bits 4096 --sec-param normal --outfile /inspircd/conf/key.pem
+    /usr/bin/certtool --generate-self-signed --load-privkey /inspircd/conf/key.pem --outfile /inspircd/conf/cert.pem --template /tmp/cert.template
+    rm /tmp/cert.template
+fi
+
+
+/inspircd/bin/inspircd --nofork $@


### PR DESCRIPTION
* Added configs for TLS
* Opened port 6697 for TLS Clients
* Opened port 7000 for plaintext servers
* Opened port 7001 for TLS Servers
* Added entrypoint script to generate TLS certificate
* Install gnutls utils to generate TLs certificates
* Fixed file and directory permissions