### PR TITLE
Add secret management to provide TLS keys and certificates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ before_install:
 
 
 script:
+  # Create swarm for explicit testing
+  # Make sure that there is a useable ip address as "advertise address" because else the swarm creation fails maybe
+  - docker swarm init --advertise-addr `ip addr s | grep global | grep -oE '((1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])' | head -n1`
   # Initial build with default parameters
   - docker build -t inspircd:testing .
   # Run all tests from test directory

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Default ports of this container image:
 |7000|server, plaintext |
 |7001|server, tls       |
 
+
 ## TLS
+
+### Using self-generated certificates
 
 This container image generates a self-signed TLS certificate on startup as long as none exists. To use this container with TLS enabled:
 
@@ -49,6 +52,26 @@ You can customize the self-signed TLS certificate using the following environmen
 * `INSP_TLS_STATE`
 * `INSP_TLS_COUNTRY`
 * `INSP_TLS_DURATION`
+
+### Using secrets
+
+We provide the ability to use `secrets` with this image to place a certificate to your nodes.
+
+**Docker version 1.13 is required and [secrets are only supported in swarm mode](https://docs.docker.com/engine/swarm/secrets/)**
+
+```console
+docker secret create irc.key /path/to/your/ircd.key
+docker secret create inspircd.crt /path/to/your/ircd.crt
+
+docker service create --name inspircd --secret source=irc.key,target=inspircd.key,mode=0400 --secret inspircd.crt inspircd/inspircd-docker
+```
+
+Notice the syntax `--secret source=irc.key,target=inspircd.key` allows you to name a secret in a way you like.
+
+Currently used secrets:
+
+* `inspircd.key`
+* `inspircd.crt`
 
 
 # Build extras

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,13 @@ else
     ln -s /conf /inspircd/conf
 fi
 
+# Link certificates from secrets
+# See https://docs.docker.com/engine/swarm/secrets/
+if [ -e /run/secrets/inspircd.key ] && [ -e /run/secrets/inspircd.crt ]; then
+    ln -s /run/secrets/inspircd.key /inspircd/conf/key.pem
+    ln -s /run/secrets/inspircd.crt /inspircd/conf/cert.pem
+fi
+
 # Make sure there is a certificate or generate an new one
 if [ ! -e /inspircd/conf/cert.pem ] && [ ! -e /inspircd/conf/key.pem ]; then
     cat > /tmp/cert.template <<EOF

--- a/tests/secrets.sh
+++ b/tests/secrets.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+echo "
+         ######################################
+         ###          Secrets test           ##
+         ######################################
+"
+
+
+# Make sure tests fails if a commend ends without 0
+set -e
+
+
+# Generate some random ports for testing
+CLIENT_PORT=$(cat /dev/urandom|od -N2 -An -i|awk -v f=10000 -v r=19999 '{printf "%i\n", f + r * $1 / 65536}')
+TLS_CLIENT_PORT=$(cat /dev/urandom|od -N2 -An -i|awk -v f=20000 -v r=29999 '{printf "%i\n", f + r * $1 / 65536}')
+SERVER_PORT=$(cat /dev/urandom|od -N2 -An -i|awk -v f=30000 -v r=39999 '{printf "%i\n", f + r * $1 / 65536}')
+TLS_SERVER_PORT=$(cat /dev/urandom|od -N2 -An -i|awk -v f=40000 -v r=49999 '{printf "%i\n", f + r * $1 / 65536}')
+
+
+# Make sure the ports are not already in use. In case they are rerun the script to get new ports.
+[ $(netstat -an | grep LISTEN | grep :$CLIENT_PORT | wc -l) -eq 0 ] || { ./$0 && exit 0 || exit 1; }
+[ $(netstat -an | grep LISTEN | grep :$TLS_CLIENT_PORT | wc -l) -eq 0 ] || { ./$0 && exit 0 || exit 1; }
+[ $(netstat -an | grep LISTEN | grep :$SERVER_PORT | wc -l) -eq 0 ] || { ./$0 && exit 0 || exit 1; }
+[ $(netstat -an | grep LISTEN | grep :$TLS_SERVER_PORT | wc -l) -eq 0 ] || { ./$0 && exit 0 || exit 1; }
+
+# Helpfunction for version compare
+version_ge() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" || test "$1" = "$2"; }
+
+# Verify that the docker version allows secrets
+version_ge $(docker version --format '{{.Server.Version}}') 1.13.0 || {
+    echo "
+         ################################################################
+         ##                                                            ##
+         ##   Docker version `docker version --format '{{.Server.Version}}'` doesn't allow to test secrets      ##
+         ##   Docker version 1.13.0 or higher required for this test.  ##
+         ##                                                            ##
+         ################################################################
+         "
+    exit 0
+}
+
+
+# Generate certificates
+cat > "/tmp/test-secrets-cert.template" <<EOF
+XZ
+Example State
+Example City
+Example IRC Network
+Secret Server Admins
+irc.example.com
+nomail@example.com
+EOF
+
+cat "/tmp/test-secrets-cert.template" | openssl req -x509 -nodes -newkey rsa:4096 -keyout "/tmp/test-secrets-key.pem" -out "/tmp/test-secrets-cert.pem" -days 365 2>/dev/null
+
+# Create secrets
+SECRETCERT=$(docker secret create test-secrets-cert /tmp/test-secrets-cert.pem)
+SECRETKEY=$(docker secret create test-secrets-key  /tmp/test-secrets-key.pem)
+
+# Run container in a simple way
+DOCKERSERVICE=$(docker service create -p ${CLIENT_PORT}:6667 -p ${TLS_CLIENT_PORT}:6697 --secret source=test-secrets-key,target=inspircd.key --secret source=test-secrets-cert,target=inspircd.crt inspircd:testing)
+sleep 35
+# Make sure TLS is working
+TLSCHECK=$(echo quit | timeout 10 openssl s_client -ign_eof -connect localhost:${TLS_CLIENT_PORT} 2>/dev/null | grep "OU=Secret Server Admins" | wc -l)
+[ $TLSCHECK -gt 0 ] || exit 1
+
+sleep 5
+# Clean up
+docker service rm ${DOCKERSERVICE} && docker secret rm ${SECRETCERT} && docker secret rm ${SECRETKEY}
+


### PR DESCRIPTION
See https://docs.docker.com/engine/swarm/secrets/

Allow improved secret handling created by docker version 1.13.

Works in Swarm mode only.