### PR TITLE
Speedup build by using shallow clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache gcc g++ make libgcc libstdc++ git  \
     mkdir -p /src /conf && \
     cd /src && \
     # Clone the requested version
-    git clone https://github.com/inspircd/inspircd.git inspircd -b $VERSION && \
+    git clone https://github.com/inspircd/inspircd.git inspircd --depth 1 -b $VERSION && \
     cd /src/inspircd && \
     # Add and overwrite modules
     { [ $(ls /src/modules/ | wc -l) -gt 0 ] && cp -r /src/modules/* /src/inspircd/src/modules/ || echo "No modules overwritten/added by repository"; } && \


### PR DESCRIPTION
Thanks to @SaberUK for the hint.

<!--

Thanks for the contribution!

We provide a little checklist for Pull Requests to make sure everything is fine.

If you are working on a pull request please add WIP to its title. We will still
  look at it and discuss if needed.
-->

## Checklist

- [x] Implementation
- [x] Tests
- [x] Docs

<!--

Some details for the checklist:

Implementation means the complete implementation of your feature.

Tests means adding a shell script in `tests/` to check that your implementation
  works correctly. This makes sure no other pull request breaks a feature. We
  would really welcome it, because simplifies our life.

Docs means additions to the README.md in case you add something which needs
  user interaction or knowledge.

Feel free to place more detail below or on top of your pull request :)

We try to create a great user experience for this image. Every contribution is
  welcome and we help you as good as we can.
-->
Details: https://www.git-scm.com/docs/git-clone#git-clone---depthltdepthgt

This should speed up the clone process during build. As we only clone the commit we need to build instead of the whole history.

No tests extra tests are needed for this change. Same applies to docs.