### PR TITLE
Add DNSBL for better default security

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -5,4 +5,6 @@ Chatspike
 
 # Technical terms
 inspircd-extras
-
+DNSBLs
+EFnet
+DroneBL

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Use the following environment variables to configure your container:
 |`INSP_ADMIN_NAME`     |`Jonny English`                 |Name shown by the `/admin` command        |
 |`INSP_ADMIN_NICK`     |`MI5`                           |Nick shown by the `/admin` command        |
 |`INSP_ADMIN_EMAIL`    |`jonny.english@example.com`     |E-mail shown by the `/admin` command      |
+|`INSP_ENABLE_DNSBL`   |`yes`                           |Set to `no` to disable DNSBLs             |
 
 A quick example how to use the environment variables:
 
@@ -152,6 +153,14 @@ docker pull inspircd/inspircd-docker
 We automatically build our images weekly to include the current state of modern libraries.
 
 Considering to update your docker setup regularly.
+
+# Additional information
+
+By default this image ships DNSBL settings for [DroneBL](http://dronebl.org) and [EFnet RBL](http://efnetrbl.org/).
+
+This should provide a basic protection for your server, but also causes problems if you want to use [Tor](https://www.torproject.org/) or open proxies.
+
+Set `INSP_ENABLE_DNSBL` to `no` to disable them.
 
 # License
 

--- a/conf/config.sh
+++ b/conf/config.sh
@@ -12,6 +12,9 @@ cat <<EOF
 <define name="adminname" value="${INSP_ADMIN_NAME:-Jonny English}">
 <define name="adminnick" value="${INSP_ADMIN_NICK:-MI5}">
 <define name="adminemail" value="${INSP_ADMIN_EMAIL:-jonny.english@example.com}">
+
+# Connect block section
+<define name="usednsbl" value="${INSP_ENABLE_DNSBL:-yes}">
 EOF
 
 # Space for further configs

--- a/conf/inspircd.conf
+++ b/conf/inspircd.conf
@@ -118,6 +118,10 @@
          # useident: Defines if users in this class must respond to a ident query or not.
          useident="no"
 
+         # usednsbl: Defines whether or not users in this class are subject to DNSBL. Default is yes.
+         # This setting only has effect when m_dnsbl is loaded.
+         usednsbl="&usednsbl;"
+
          # limit: How many users are allowed in this class
          limit="5000"
 

--- a/conf/modules.conf
+++ b/conf/modules.conf
@@ -731,10 +731,28 @@
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # DNS blacklist module: Provides support for looking up IPs on one or #
 # more blacklists.                                                    #
-#<module name="m_dnsbl.so">                                           #
+<module name="m_dnsbl.so">                                           #
 #                                                                     #
 # For configuration options please see the wiki page for m_dnsbl at   #
 # http://wiki.inspircd.org/Modules/dnsbl                              #
+
+<dnsbl name="dnsbl.dronebl.org"
+    type="record"
+    domain="dnsbl.dronebl.org"
+    action="ZLINE"
+    reason="You are listed in DroneBL. Please visit http://dronebl.org/lookup?ip=%ip%"
+    duration="1d"
+    records="1,2,4,8,16,3,4,5,10,14,17,19"
+>
+
+<dnsbl name="rbl.efnetrbl.org"
+    type="record"
+    domain="rbl.efnetrbl.org"
+    action="ZLINE"
+    reason="Blacklisted Proxy found.  Visit http://rbl.efnetrbl.org/?i=%ip%"
+    duration="1d"
+    records="1,2,3,4,5"
+>
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Exempt channel operators module: Provides support for allowing      #


### PR DESCRIPTION
<!--

Thanks for the contribution!

We provide a little checklist for Pull Requests to make sure everything is fine.

If you are working on a pull request please add WIP to its title. We will still
  look at it and discuss if needed.
-->

## Checklist

- [x] Implementation
- [x] Tests
- [x] Docs

<!--

Some details for the checklist:

Implementation means the complete implementation of your feature.

Tests means adding a shell script in `tests/` to check that your implementation
  works correctly. This makes sure no other pull request breaks a feature. We
  would really welcome it, because simplifies our life.

Docs means additions to the README.md in case you add something which needs
  user interaction or knowledge.

Feel free to place more detail below or on top of your pull request :)

We try to create a great user experience for this image. Every contribution is
  welcome and we help you as good as we can.
-->

Adds DroneBL and EFnet RBL as preconfigured Blacklists. As part of secure defaults that's a good way to protect servers with small efford.

It's still possible to disable them by adding `-e INSP_ENABLE_DNSBL=no` as part run command so it should stay universal.

Currently are no tests provided. I won't mind if it stays untested (in speech of automated testing) as disable them should be a corner case.