### PR TITLE
Allow extending config by secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,18 @@ $ docker run --name inspircd -p 6667:6667 -v /path/to/your/configs:/inspircd/con
 copy or mount it to `/inspircd/conf/` instead of `/inspircd/conf.d/`.*
 
 
+### Using secrets
+
+Additional to the `conf.d/` directory we offer a automated includes for all `.conf` files that are mounted as secrets.
+
+For example to add your own oper configuration.
+
+```console
+docker secret create secret-opers /path/to/your/opers.conf
+
+docker service create --name inspircd --secret secret-opers inspircd/inspircd-docker
+```
+
 # Build extras
 
 To build extra modules you can use the `--build-arg` statement.

--- a/conf/config.sh
+++ b/conf/config.sh
@@ -23,4 +23,9 @@ if [ -d conf.d ]; then
     find conf.d/*.conf | while read -r file; do echo "<include file=\"$file\">"; done
 fi
 
+# Include custom configurations from docker secrets. (For example for further oper configs)
+if [ -d /run/secrets ]; then
+    find /run/secrets/*.conf | while read -r file; do echo "<include file=\"$file\">"; done
+fi
+
 # Space for further configs

--- a/tests/customConfigSecrets.sh
+++ b/tests/customConfigSecrets.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+echo "
+         ######################################
+         ###     Secret custom conf test     ##
+         ######################################
+"
+
+
+# Make sure tests fails if a command exits with non-zero
+set -e
+
+# shellcheck source=tests/.portconfig.sh
+. $(dirname "$0")/.portconfig.sh
+
+# Helpfunction for version compare
+version_ge() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" || test "$1" = "$2"; }
+
+# Verify that the docker version allows secrets
+version_ge "$(docker version --format '{{.Server.Version}}')" 1.13.0 || {
+    echo "
+         ################################################################
+         ##                                                            ##
+         ##   Docker version $(docker version --format '{{.Server.Version}}') doesn't allow to test secrets      ##
+         ##   Docker version 1.13.0 or higher required for this test.  ##
+         ##                                                            ##
+         ################################################################
+         "
+    exit 0
+}
+
+TESTFILE="/tmp/tests-customConfig/test.conf"
+
+mkdir -p "$(dirname $TESTFILE)"
+
+echo "<module name=\"m_cban.so\">" >"$TESTFILE"
+
+SECRETCONFIG=$(docker secret create test-config  "$TESTFILE")
+
+# Run service with configs attached
+DOCKERSERVICE=$(docker service create -p "${CLIENT_PORT}:6667" -p "${TLS_CLIENT_PORT}:6697" --secret source=test-config,target=test.conf inspircd:testing)
+
+sleep 40
+
+
+docker service logs "$DOCKERSERVICE" | grep "m_cban.so"
+
+# Clean up
+docker service rm "${DOCKERSERVICE}" && docker secret rm "$SECRETCONFIG"


### PR DESCRIPTION
<!--

Thanks for the contribution!

We provide a little checklist for Pull Requests to make sure everything is fine.

If you are working on a pull request please add WIP to its title. We will still
  look at it and discuss if needed.
-->

## Checklist

- [x] Implementation
- [x] Tests
- [x] Docs

<!--

Some details for the checklist:

Implementation means the complete implementation of your feature.

Tests means adding a shell script in `tests/` to check that your implementation
  works correctly. This makes sure no other pull request breaks a feature. We
  would really welcome it, because simplifies our life.

Docs means additions to the README.md in case you add something which needs
  user interaction or knowledge.

Feel free to place more detail below or on top of your pull request :)

We try to create a great user experience for this image. Every contribution is
  welcome and we help you as good as we can.
-->

As some parts of the config like the cloaking config, linking passwords, or oper passwords are sensitive data, they should be able to use `secrets`. This way we can include any config file in `/run/secrets/` and allow exactly this.